### PR TITLE
Using withoutTransitivity() to resolve gems

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ public class BasicTest {
         File asciidoctorGem = Maven.configureResolver() // <2>
                 .withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
                 .resolve("rubygems:asciidoctor:gem:1.5.2")
-                .withTransitivity().asSingleFile();
+                .withoutTransitivity().asSingleFile();
 
         return ShrinkWrap.create(GenericArchive.class)
                 .add(new FileAsset(asciidoctorGem), asciidoctorGem.getName())

--- a/src/test/java/foo/test/BasicTest.java
+++ b/src/test/java/foo/test/BasicTest.java
@@ -29,7 +29,7 @@ public class BasicTest {
         File asciidoctorGem = Maven.configureResolver()
                 .withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
                 .resolve("rubygems:asciidoctor:gem:1.5.2")
-                .withTransitivity().asSingleFile();
+                .withoutTransitivity().asSingleFile();
 
         return ShrinkWrap.create(GenericArchive.class)
                 .add(new FileAsset(asciidoctorGem), asciidoctorGem.getName())

--- a/src/test/java/org/arquillian/jruby/embedded/JRubyCachedTest.java
+++ b/src/test/java/org/arquillian/jruby/embedded/JRubyCachedTest.java
@@ -32,7 +32,7 @@ public class JRubyCachedTest {
     public static JavaArchive deploy() throws Exception {
         return ShrinkWrap.create(JavaArchive.class)
                 .addAsResource(Maven.configureResolver().withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
-                        .resolve("rubygems:asciidoctor:gem:1.5.2").withTransitivity().asFile()[0]);
+                        .resolve("rubygems:asciidoctor:gem:1.5.2").withoutTransitivity().asSingleFile());
     }
 
     @Test

--- a/src/test/java/org/arquillian/jruby/embedded/JRubyUncachedTest.java
+++ b/src/test/java/org/arquillian/jruby/embedded/JRubyUncachedTest.java
@@ -32,7 +32,7 @@ public class JRubyUncachedTest {
     public static JavaArchive deploy() throws Exception {
         return ShrinkWrap.create(JavaArchive.class)
                 .addAsResource(Maven.configureResolver().withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
-                        .resolve("rubygems:asciidoctor:gem:1.5.2").withTransitivity().asFile()[0]);
+                        .resolve("rubygems:asciidoctor:gem:1.5.2").withoutTransitivity().asSingleFile());
     }
 
     @Test

--- a/src/test/java/org/arquillian/jruby/gems/JRubyGemCacheTest.java
+++ b/src/test/java/org/arquillian/jruby/gems/JRubyGemCacheTest.java
@@ -22,7 +22,7 @@ public class JRubyGemCacheTest {
     @BeforeClass
     public static void resolveAsciidoctorGem() {
         asciidoctorGem = Maven.configureResolver().withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
-                .resolve("rubygems:asciidoctor:gem:1.5.2").withTransitivity().asFile()[0];
+                .resolve("rubygems:asciidoctor:gem:1.5.2").withoutTransitivity().asSingleFile();
     }
 
     @Test

--- a/src/test/java/org/arquillian/jruby/gems/JRubyGemInstallerTest.java
+++ b/src/test/java/org/arquillian/jruby/gems/JRubyGemInstallerTest.java
@@ -20,7 +20,7 @@ public class JRubyGemInstallerTest {
     @BeforeClass
     public static void resolveAsciidoctorGem() throws Exception {
         asciidoctorGem = Maven.configureResolver().withRemoteRepo("rubygems", "http://rubygems-proxy.torquebox.org/releases", "default")
-                .resolve("rubygems:asciidoctor:gem:1.5.2").withTransitivity().asFile()[0];
+                .resolve("rubygems:asciidoctor:gem:1.5.2").withoutTransitivity().asSingleFile();
     }
 
     @Test


### PR DESCRIPTION
To my understanding, it does not make sense to resolve all dependencies of a gem (by using `withTransitivity()`) if people are interested only in the first artifact.

Hence, replacing all `withTransitivity().asFile()[0]` with `withoutTransitivity().asSingleFile()`

@robertpanzer also let me know if you find any way how to make SWR better for your purpose - maybe exposing some gem metadata, e.g. `resolve(...).withoutTransitivity().as(Gem.class)` or maybe some shortcut for default gem repository.
